### PR TITLE
Fix wrong panel link

### DIFF
--- a/a/html/oki/panel/panel.html
+++ b/a/html/oki/panel/panel.html
@@ -141,7 +141,7 @@
               <ul>
                 <li><a href="http://okfn.org/about/vision/">Our Vision</a></li>
                 <li><a href="http://okfn.org/about/team/">Our Team</a></li>
-                <li><a href="http://okfn.org/jobs/">Careers</a></li>
+                <li><a href="http://okfn.org/about/jobs/">Careers</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Link to /jobs results in 404, the working link is http://okfn.org/about/jobs.

See also: https://github.com/okfn/opendefinition/pull/149

It looks like the opendefinition version of the panel is a copy of this one. It's not clear to me which one is currently in use on opendefinition.org, but I'm guessing this one is used everywhere else, so needs a fix