### PR TITLE
Reimplement Google Analytics through tag.js

### DIFF
--- a/a/html/oki/consent/assets/js/consent.js
+++ b/a/html/oki/consent/assets/js/consent.js
@@ -1,4 +1,4 @@
-var dc = 'https://www.googletagmanager.com/gtag/js?id=' + googleAnalyticsCode.id;
+var dc = 'https://www.googletagmanager.com/gtag/js?id=' + okiConsent.analyticsTrackingID;
 var ac = 'https://www.google-analytics.com/analytics.js';
 
 document.addEventListener("DOMContentLoaded", function () {
@@ -54,7 +54,7 @@ window.addEventListener("load", function () {
     }
     gtag('js', new Date());
 
-    gtag('config', googleAnalyticsCode.id, {});
+    gtag('config', okiConsent.analyticsTrackingID, {});
   }
 
   function ga_reset() {

--- a/a/html/oki/consent/index.html
+++ b/a/html/oki/consent/index.html
@@ -9,7 +9,7 @@
   <meta name="description" content="Cookie Consent implementation for Open Knowledge International websites">
   <script>
     var googleAnalyticsCode = {
-      id: 'UA-XXXXXXXX-X'
+      id: 'UA-XXXXXX-XX'
     }
   </script>
   <script src="assets/js/consent.js"></script>

--- a/a/html/oki/consent/index.html
+++ b/a/html/oki/consent/index.html
@@ -8,8 +8,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Cookie Consent implementation for Open Knowledge International websites">
   <script>
-    var googleAnalyticsCode = {
-      id: 'UA-XXXXXX-XX'
+    var okiConsent = {
+      analyticsTrackingID: 'UA-XXXXXX-XX'
     }
   </script>
   <script src="assets/js/consent.js"></script>


### PR DESCRIPTION
This PR reimplements Google Analytics through tag.js to support subdomains automatically. Also, makes sure cookies are removed upon revoking the approval to set them.

Code is somewhat simplified and refactored.