### PR TITLE
Fix duplicate gtag.js includes and specify cookie_domain hostname for GA

### DIFF
--- a/a/html/oki/consent/assets/js/consent.js
+++ b/a/html/oki/consent/assets/js/consent.js
@@ -40,12 +40,16 @@ window.addEventListener("load", function () {
   }
 
   function ga_init() {
-    var head = document.getElementsByTagName('head')[0];
-    var ga = document.createElement('script');
-    ga.type = 'text/javascript';
-    ga.async = true;
-    ga.src = dc;
-    head.appendChild(ga);
+    var gaInit = 'ga-init';
+    if (!document.getElementById(gaInit)) {
+      var head = document.getElementsByTagName('head')[0];
+      var ga = document.createElement('script');
+      ga.id = gaInit;
+      ga.type = 'text/javascript';
+      ga.async = true;
+      ga.src = dc;
+      head.appendChild(ga);
+    }
 
     window.dataLayer = window.dataLayer || [];
 
@@ -54,7 +58,9 @@ window.addEventListener("load", function () {
     }
     gtag('js', new Date());
 
-    gtag('config', okiConsent.analyticsTrackingID, {});
+    gtag('config', okiConsent.analyticsTrackingID, {
+      'cookie_domain': window.location.hostname,
+    });
   }
 
   function ga_reset() {


### PR DESCRIPTION
This PR makes sure that the `gtag.js` script is not loaded more then once upon clicking Allow cookies and specifies an the GA cookie_domain explicitly from `window.location.host`.