### PR TITLE
set 2 hour cache header when we sync to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ script:
   - pip install awscli
 deploy:
   provider: script
-  script: aws s3 sync a s3://a.okfn.org
+  script: aws s3 sync --cache-control max-age=7200 a s3://a.okfn.org
   on:
     branch: master


### PR DESCRIPTION
As discussed on slack, I have:

* Updated all the existing files in the a.okfn.org bucket to serve a `Cache-Control: max-age=7200` header by running: `s3cmd --recursive modify --add-header="Cache-Control: max-age=7200" s3://a.okfn.org`
* Switched `okfn.org`'s Browser Cache TTL setting in CloudFlare to "Respect Existing Headers"

This PR updates the deploy script so that when we add/change files, the new/changed files will also be deployed with the `Cache-Control: max-age=7200` header.
